### PR TITLE
issue #15 【Dialog Memory】lodqaからのuser_idパラメータがある場合は、履歴としてDialogテーブルへの登録/更新

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ Lint/AmbiguousBlockAssociation:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 16
+  Max: 20
 
 Metrics/BlockLength:
   Max: 26

--- a/app/controllers/searches_api_controller.rb
+++ b/app/controllers/searches_api_controller.rb
@@ -46,6 +46,7 @@ class SearchesApiController < ActionController::API
       sparql_limit
       answer_limit
       target
+      user_id
       private
       callback_url
     ]

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -42,7 +42,6 @@ class Search < ApplicationRecord
     end
 
     # Expert mode check does a same condition search exists?
-    # rubocop:disable Metrics/AbcSize
     def expert_equals_in other
       Search.alive?
             .joins(pseudo_graph_pattern: :term_mappings)
@@ -56,7 +55,6 @@ class Search < ApplicationRecord
             .order(created_at: :desc)
             .first
     end
-    # rubocop:enable Metrics/AbcSize
 
     # Start to search and save the start time.
     def start! search_id

--- a/app/models/search_parameter.rb
+++ b/app/models/search_parameter.rb
@@ -16,7 +16,6 @@ class SearchParameter
             :answer_limit,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
-  # rubocop:disable Metrics/AbcSize
   def initialize params
     self.query = params[:query]
     self.pgp = convert_param_to_json(params[:pgp])
@@ -29,7 +28,6 @@ class SearchParameter
     self.private = params[:cache] == 'no'
     self.callback_url = params[:callback_url]
   end
-  # rubocop:enable Metrics/AbcSize
 
   def simple_mode?
     query.present?

--- a/app/models/search_parameter.rb
+++ b/app/models/search_parameter.rb
@@ -16,6 +16,7 @@ class SearchParameter
             :answer_limit,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
+  # rubocop:disable Metrics/AbcSize
   def initialize params
     self.query = params[:query]
     self.pgp = convert_param_to_json(params[:pgp])
@@ -28,6 +29,7 @@ class SearchParameter
     self.private = params[:cache] == 'no'
     self.callback_url = params[:callback_url]
   end
+  # rubocop:enable Metrics/AbcSize
 
   def simple_mode?
     query.present?

--- a/app/models/search_parameter.rb
+++ b/app/models/search_parameter.rb
@@ -8,8 +8,8 @@ class SearchParameter
   include ActiveModel::Model
 
   attr_accessor :query, :pgp, :mappings, \
-                :read_timeout, :sparql_limit, :answer_limit, :target, :private, \
-                :callback_url
+                :read_timeout, :sparql_limit, :answer_limit, :target, :user_id, \
+                :private, :callback_url
 
   validates :read_timeout,
             :sparql_limit,
@@ -24,6 +24,7 @@ class SearchParameter
     self.sparql_limit = params[:sparql_limit] || 100
     self.answer_limit = params[:answer_limit] || 10
     self.target = params[:target] || acquire_targets
+    self.user_id = params[:user_id]
     self.private = params[:cache] == 'no'
     self.callback_url = params[:callback_url]
   end

--- a/app/services/register_search_service.rb
+++ b/app/services/register_search_service.rb
@@ -54,6 +54,7 @@ module RegisterSearchService
     end
 
     # Start new job for new search.
+    # rubocop:disable Metrics/AbcSize
     def start_search_job search_param, pgp, callback_url
       pseudo_graph_pattern = PseudoGraphPattern.create pgp: pgp,
                                                        target: search_param.target,
@@ -64,13 +65,16 @@ module RegisterSearchService
       create_term_mapping pseudo_graph_pattern, search_param unless search_param.simple_mode?
 
       search = create_search search_param.query, pseudo_graph_pattern
-      create_dialog search_param.user_id , search if search_param.simple_mode? && search_param.user_id.present?
+      if search_param.simple_mode? && search_param.user_id.present?
+        create_dialog search_param.user_id, search
+      end
 
       SearchJob.perform_later search.search_id
       LateCallbacks.add_for search, callback_url
 
       search.search_id
     end
+    # rubocop:enable Metrics/AbcSize
 
     def create_term_mapping pseudo_graph_pattern, search_param
       TermMapping.create pseudo_graph_pattern: pseudo_graph_pattern,

--- a/app/services/register_search_service.rb
+++ b/app/services/register_search_service.rb
@@ -54,7 +54,6 @@ module RegisterSearchService
     end
 
     # Start new job for new search.
-    # rubocop:disable Metrics/AbcSize
     def start_search_job search_param, pgp, callback_url
       pseudo_graph_pattern = PseudoGraphPattern.create pgp: pgp,
                                                        target: search_param.target,
@@ -74,7 +73,6 @@ module RegisterSearchService
 
       search.search_id
     end
-    # rubocop:enable Metrics/AbcSize
 
     def create_term_mapping pseudo_graph_pattern, search_param
       TermMapping.create pseudo_graph_pattern: pseudo_graph_pattern,

--- a/app/services/register_search_service.rb
+++ b/app/services/register_search_service.rb
@@ -64,6 +64,7 @@ module RegisterSearchService
       create_term_mapping pseudo_graph_pattern, search_param unless search_param.simple_mode?
 
       search = create_search search_param.query, pseudo_graph_pattern
+      create_dialog search_param.user_id , search if search_param.simple_mode? && search_param.user_id.present?
 
       SearchJob.perform_later search.search_id
       LateCallbacks.add_for search, callback_url
@@ -75,6 +76,15 @@ module RegisterSearchService
       TermMapping.create pseudo_graph_pattern: pseudo_graph_pattern,
                          dataset_name: search_param.target,
                          mapping: search_param.mappings
+    end
+
+    def create_dialog user_id, search
+      dialog = search.dialogs.where(user_id: user_id)
+      if dialog.present?
+        dialog.update(updated_at: Time.now.utc)
+      else
+        search.dialogs.create(user_id: user_id)
+      end
     end
 
     def create_search query, pseudo_graph_pattern

--- a/db/migrate/20200207064024_create_dialogs.rb
+++ b/db/migrate/20200207064024_create_dialogs.rb
@@ -8,5 +8,6 @@ class CreateDialogs < ActiveRecord::Migration[6.0]
     end
 
     add_foreign_key :dialogs, :searches
+    add_index       :dialogs, [:user_id, :search_id], unique: true, name: 'index_dialogs_searches_on_user_id_and_search_id'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2020_02_07_064024) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["search_id"], name: "index_dialogs_on_search_id"
+    t.index ["user_id", "search_id"], name: "index_dialogs_searches_on_user_id_and_search_id", unique: true
   end
 
   create_table "events", force: :cascade do |t|


### PR DESCRIPTION
#15 

lodqaにてシンプルモード・loginして検索された場合のみ、
bs側でloginしたメールアドレス（user_idとしている）を履歴としてDialogテーブルへの登録・更新（更新日）を行う。