### PR TITLE
issue #17 ユーザの対話歴を取得元編集

### DIFF
--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -23,7 +23,7 @@ class SearchJob < ApplicationJob
 
   def run search, user_id
     Lodqa::Search.start search.pseudo_graph_pattern,
-                        Search.dialog_history(user_id),
+                        Dialog.history(user_id),
                         on_start(search),
                         on_event(search),
                         logger

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -3,4 +3,11 @@
 # If user_id is specified, register it in the Dialog table.
 class Dialog < ApplicationRecord
   belongs_to :search
+
+  # Get user dialog history
+  def self.history user_id
+    return [] unless user_id.present?
+
+    where(user_id: user_id)
+  end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -3,7 +3,6 @@
 require 'securerandom'
 
 # The search accepted.
-# rubocop:disable Metrics/ClassLength
 class Search < ApplicationRecord
   include Subscribable
 
@@ -154,4 +153,3 @@ class Search < ApplicationRecord
     Event.reader_by offset_size, pseudo_graph_pattern: pseudo_graph_pattern
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -63,13 +63,6 @@ class Search < ApplicationRecord
       search.pseudo_graph_pattern.update(started_at: Time.now.utc)
       search
     end
-
-    # Get user dialog history
-    def dialog_history user_id
-      return [] unless user_id.present?
-
-      Search.includes(:dialogs).where(dialogs: { user_id: user_id })
-    end
   end
 
   def append_dialog user_id


### PR DESCRIPTION
#17 

ユーザの対話歴を取得元変更修正。
`Search.includes(:dialogs).where(dialogs: { user_id: user_id })` →　`Dialog.where(user_id: user_id)`
